### PR TITLE
fixed timestamp MarshalJSON

### DIFF
--- a/nmap.go
+++ b/nmap.go
@@ -27,7 +27,7 @@ func (t Timestamp) time2str() string {
 }
 
 func (t Timestamp) MarshalJSON() ([]byte, error) {
-	return []byte(t.time2str()), nil
+	return []byte(fmt.Sprintf("\"%s\"", t.time2str())), nil
 }
 
 func (t Timestamp) UnmarshalJSON(b []byte) error {


### PR DESCRIPTION
Timestamp.MarshalJSON returned unquoted string which is not allowed in json.