### PR TITLE
Fix Marshal producing data Unmarshal can't parse

### DIFF
--- a/nmap.go
+++ b/nmap.go
@@ -3,38 +3,38 @@ package nmap
 
 import (
 	"encoding/xml"
-	"fmt"
 	"strconv"
 	"time"
 )
 
+// Timestamp represents time as a UNIX timestamp in seconds.
 type Timestamp time.Time
 
 // str2time converts a string containing a UNIX timestamp to to a time.Time.
-func (t *Timestamp) str2time(s string) (err error) {
-	ts, err := strconv.Atoi(s)
+func (t *Timestamp) str2time(s string) error {
+	ts, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
-		return
+		return err
 	}
-	*t = Timestamp(time.Unix(int64(ts), 0))
-	return
+	*t = Timestamp(time.Unix(ts, 0))
+	return nil
 }
 
 // time2str formats the time.Time value as a UNIX timestamp string.
 // XXX these might also need to be changed to pointers. See str2time and UnmarshalXMLAttr.
 func (t Timestamp) time2str() string {
-	return fmt.Sprint(time.Time(t))
+	return strconv.FormatInt(time.Time(t).Unix(), 10)
 }
 
 func (t Timestamp) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("\"%s\"", t.time2str())), nil
+	return []byte(t.time2str()), nil
 }
 
-func (t Timestamp) UnmarshalJSON(b []byte) error {
+func (t *Timestamp) UnmarshalJSON(b []byte) error {
 	return t.str2time(string(b))
 }
 
-func (t *Timestamp) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+func (t Timestamp) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
 	return xml.Attr{Name: name, Value: t.time2str()}, nil
 }
 


### PR DESCRIPTION
As it currently stands, the marshaling functions print a string
containing the default string representation for time.Time, which is a
reading of the time in the format 2006-01-02 15:04:05.999999999 -0700
MST.
However, this input cannot be accepted not even by the Unmarshaler
itself, because it expects an integer, not Go's default format.

There are, of course, concerns in regard to backwards compatibility.
However, as it currently stands, with the default String()
representation, the result can change based on the used Go version - in
fact, in 1.9 the representation changed to account for the introduction
of the monotonic clock. Because the representation has already changed
in the past and has no guarantee not to change in the future, I suggest
it's best to switch to a known format even if it means breaking
compatibility.

