### PR TITLE
Fix script output parsing

### DIFF
--- a/nmap.go
+++ b/nmap.go
@@ -218,9 +218,10 @@ type CPE string
 
 // Script contains information from Nmap Scripting Engine.
 type Script struct {
-	Id     string  `xml:"id,attr" json:"id"`
-	Output string  `xml:"output,attr" json:"output"`
-	Tables []Table `xml:"table" json:"tables"`
+	Id       string    `xml:"id,attr" json:"id"`
+	Output   string    `xml:"output,attr" json:"output"`
+	Tables   []Table   `xml:"table" json:"tables"`
+	Elements []Element `xml:"elem" json:"elements"`
 }
 
 // Table contains the output of the script in a more parse-able form.

--- a/nmap.go
+++ b/nmap.go
@@ -226,8 +226,15 @@ type Script struct {
 // Table contains the output of the script in a more parse-able form.
 // ToDo: This should be a map[string][]string
 type Table struct {
-	Key      string   `xml:"key,attr" json:"key"`
-	Elements []string `xml:"elem" json:"elements"`
+	Key      string    `xml:"key,attr" json:"key"`
+	Elements []Element `xml:"elem" json:"elements"`
+	Table    []Table   `xml:"table" json:"tables"`
+}
+
+// Element contains the output of the script, with detailed information
+type Element struct {
+	Key   string `xml:"key,attr" json:"key"`
+	Value string `xml:",chardata" json:"value"`
 }
 
 // Os contains the fingerprinted operating system for a Host.


### PR DESCRIPTION
- This commit propose adding a new type Element to better parse the
script output. Also add a nested Table type to capture outputs from
scripts such as ssl-enum-cipher script

Sample output difference in JSON
Before - https://gist.github.com/adifire/721e2a64f17b8d779b720675b3466678
After - https://gist.github.com/adifire/9106d4bc8a0bb408d11522a556f6b2a0
