### PR TITLE
fix osgen cannot parse.

### DIFF
--- a/nmap.go
+++ b/nmap.go
@@ -255,7 +255,7 @@ type PortUsed struct {
 // OsClass contains vendor information for an Os.
 type OsClass struct {
 	Vendor   string `xml:"vendor,attr" json:"vendor"`
-	OsGen    string `xml"osgen,attr"`
+	OsGen    string `xml:"osgen,attr" json:"osgen"`
 	Type     string `xml:"type,attr" json:"type"`
 	Accuracy string `xml:"accurancy,attr" json:"accurancy"`
 	OsFamily string `xml:"osfamily,attr" json:"osfamily"`


### PR DESCRIPTION
I found that osgen always has no value in the process of using it. I saw that there is a problem with the label in the code. And fixes, request merges

Before fix:
```
OsGen    string `xml"osgen,attr" `
```

After fix:
```
OsGen    string `xml:"osgen,attr" json:"osgen"`
```