### PR TITLE
Updated to match nmap.dtd

### DIFF
--- a/nmap.go
+++ b/nmap.go
@@ -112,6 +112,7 @@ type Target struct {
 type Host struct {
 	StartTime     Timestamp     `xml:"starttime,attr" json:"starttime"`
 	EndTime       Timestamp     `xml:"endtime,attr" json:"endtime"`
+	TimedOut      bool          `xml:"timedout,attr" json:"timedout"`
 	Comment       string        `xml:"comment,attr" json:"comment"`
 	Status        Status        `xml:"status" json:"status"`
 	Addresses     []Address     `xml:"address" json:"addresses"`


### PR DESCRIPTION
The nmap XML has been updated since the project was created. This commit
adds an updated attribute to match the upstream nmap XML output. See the
following nmap commit from May 21,2021:

- https://github.com/nmap/nmap/commit/14c7f87d6fb109b6248d620ff3c19c054d9d4204

Only thing of note is that this is the only attribute that is boolean.